### PR TITLE
Use legacy open ssl

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "netlify-lambda serve src",
-    "build": "netlify-lambda build src",
+    "build": "NODE_OPTIONS='--openssl-legacy-provider' netlify-lambda build src",
     "test": "jest"
   },
   "keywords": [


### PR DESCRIPTION
Based on https://answers.netlify.com/t/error-while-deploying-netlify/94592